### PR TITLE
ユーザー・管理者認証テストのアサーションを書き換え #19

### DIFF
--- a/tests/Feature/AdminTest.php
+++ b/tests/Feature/AdminTest.php
@@ -4,15 +4,14 @@ namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Support\Facades\Auth;
 use Tests\TestCase;
 use App\Models\Admin;
 
 class AdminTest extends TestCase
 {
     use RefreshDatabase;
- 
-    public function testAuthentication()
+    
+    public function testLogin()
     {
         $this->withoutExceptionHandling();
         
@@ -20,18 +19,29 @@ class AdminTest extends TestCase
             'password'  =>  bcrypt('test1234')
         ]);
 
-        $this->assertFalse(Auth::guard('admin')->check());
+        $this->assertGuest($guard = 'admin');
         
         $response = $this->post(route('admin.login'), [
             'email'     =>  $admin->email,
             'password'  =>  'test1234',
         ]); 
         
-        $this->assertTrue(Auth::guard('admin')->check());
+        $this->assertAuthenticatedAs($admin, $guard = 'admin');
         $response->assertRedirect(route('admin_home'));
+    }
+   
+    public function testLogout()
+    {
+        $this->withoutExceptionHandling();
         
+        $admin = factory(Admin::class)->create();
+        $this->actingAs($admin, 'admin');
+ 
+        $this->assertAuthenticatedAs($admin, $guard = 'admin');
+
         $response = $this->post(route('admin.logout')); 
-        $this->assertFalse(Auth::guard('admin')->check());
+        
+        $this->assertGuest($guard = 'admin');
         $response->assertRedirect(route('admin.login'));
     }
 }

--- a/tests/Feature/HttpTest.php
+++ b/tests/Feature/HttpTest.php
@@ -9,11 +9,11 @@ use App\Models\User;
 use App\Models\Post;
 use App\Models\Comment;
 
-class SampleTest extends TestCase
+class HttpTest extends TestCase
 {
     use RefreshDatabase;
  
-    public function testHttp()
+    public function testHttp() 
     {
         $this->assertTrue(true);
         

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Support\Facades\Auth;
 use Tests\TestCase;
 use App\Models\User;
 
@@ -20,14 +19,14 @@ class UserTest extends TestCase
             'password'  =>  bcrypt('test1234')
         ]);
         
-        $this->assertFalse(Auth::check());
+        $this->assertGuest();
  
         $response = $this->post(route('login'), [
             'email'     =>  $user->email,
             'password'  =>  'test1234',
         ]); 
         
-        $this->assertTrue(Auth::check());
+        $this->assertAuthenticatedAs($user);
         $response->assertRedirect('/');
     }
     
@@ -38,11 +37,11 @@ class UserTest extends TestCase
         $user = factory(User::class)->create();
         $this->actingAs($user);
     
-        $this->assertTrue(Auth::check());
+        $this->assertAuthenticatedAs($user);
 
-        $response = $this->post(route('logout')); 
+        $response = $this->post(route('logout'));  
         
-        $this->assertFalse(Auth::check());
+        $this->assertGuest();
         $response->assertRedirect('/');
     }
 }


### PR DESCRIPTION
アサーションの書き換え、AdminテストのメソッドをLoginとLogoutに分けて、SampleTest.phpの名前をHttpTest.phpに変更したため。