### PR TITLE
記事詳細画面にユーザー名と画像を表示し、他の画面の見た目を調整 #28

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -33,7 +33,7 @@ class PostsController extends Controller
         return view('posts.show')->with('post', $post)->with('login_user_id', $login_user_id);
     }
 
-    public function create(Request $request, Symbol $symbol){
+    public function create(Request $request){
         $symbols = Symbol::all();
         $selected_symbol = $request->input('selected_symbol');
         return view('posts.create')->with('symbols', $symbols)->with('selected_symbol', $selected_symbol);

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -32,8 +32,8 @@ class PostsTableSeeder extends Seeder
             ],
             [
                 'title'            => '行ってみたい国',
-                'body'             => '  I.イタリア
- II.フランス 
+                'body'             => 'I.イタリア
+II.フランス 
 III.イギリス',
                 'user_id'          => 4,
                 'created_at'       => date('Y-m-d H:i:2'),
@@ -60,8 +60,8 @@ III.イギリス',
             [
                 'title'            => '好きな季節',
                 'body'             => '・秋
-・
-・',
+・春
+・冬',
                 'user_id'          => 2,
                 'created_at'       => date('Y-m-d H:i:5'),
                 'updated_at'       => date('Y-m-d H:i:5'),

--- a/database/seeds/SymbolsTableSeeder.php
+++ b/database/seeds/SymbolsTableSeeder.php
@@ -26,7 +26,7 @@ class SymbolsTableSeeder extends Seeder
             ],
             [
                 'symbol'    => 'I. II. III.',
-                'body'      => '  I.
+                'body'      => 'I.
 II.
 III.',
             ],

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -3,11 +3,11 @@
 @section('title', '新規投稿')
 
 @section('content')
-    <h1 class="mb-5">
+    <h1 class="mb-4">
         @include('layouts.return')    
         新規投稿
     </h1>
-    <form method="get" action="{{ route('create') }}" class="form-inline">
+    <form method="get" action="{{ route('create') }}" class="form-inline ml-2">
         <div class="form-group">
                 <select class="form-control custom-select border-info" name="selected_symbol">
                     <option disabled selected hidden>記号を選ぶ</option>
@@ -18,7 +18,7 @@
         </div> 
         <button type="submit" class="btn btn-dark text-warning">選択</button>
     </form>
-    <form method="post" action="{{ url('/posts') }}">
+    <form method="post" action="{{ url('/posts') }}" class="ml-2">
         @csrf
         <div class="form-group">
                 <input type="text" name="title" placeholder="タイトルを入力" value="{{ old('title') }}" class="form-control border-info mt-4">

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -3,11 +3,11 @@
 @section('title', '編集')
 
 @section('content')
-    <h1 class="mb-5">
+    <h1 class="mb-4">
         @include('layouts.return')    
         編集
     </h1>
-    <form method="post" action="{{ url('/posts', $post->id) }}">
+    <form method="post" action="{{ url('/posts', $post->id) }}" class="ml-2">
         @csrf
         {{ method_field('patch') }}
         <div class="form-group">

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -4,12 +4,12 @@
 
 @section('content')
 
-    <h1 class="mb-5">
+    <h1 class="mb-4">
      MyTop3
         <a href="{{ route('create') }}" class="btn btn-outline-primary float-right">投稿する</a>
     </h1>
       @include('posts.search')
-      <table class="table table-striped table-hover mt-5">
+      <table class="table table-striped table-hover mt-2">
           <tr>
             <th>
               タイトル
@@ -29,20 +29,14 @@
         @forelse ($posts as $post)
           <tr>
             <td>
-                <a href="{{ route('show', $post) }}" class="font-weight-bold">{{ $post->title }}</a>
+                <u><a href="{{ route('show', $post) }}" class="font-weight-bold">{{ $post->title }}</a><u>
             </td>
             <td class="text-center text-secondary font-weight-bold pl-5">
-            {{ optional($post->user)->name }}
+              @if (!$post->user->image == null)
+                <img src="{{ asset('/storage/' . $post->user->image) }}" width="50" height="50">
+              @endif
+              {{ optional($post->user)->name }}
             </td>
-            @if (!$post->user->image == null)
-              <td>
-                <a href="{{ route('profile_image') }}">
-                  <img src="{{ asset('/storage/' . $post->user->image) }}" width="50" height="50">
-                </a>
-              </td>           
-            @else
-              <td></td>
-            @endif
             @auth
               @if ($post->user_id === $login_user_id)
                 <td class="text-center">

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -4,15 +4,20 @@
 
 @section('content')
     
-    <h1>
+    <h6 class="text-secondary">
+        @if (!$post->user->image == null)
+            <img src="{{ asset('/storage/' . $post->user->image) }}" width="50" height="50">
+        @endif
+        {{ $post->user->name }}
         @include('layouts.return')    
+    </h6>
+    <h3 class="mt-4 mb-4 ml-3 text-danger">
         {{ $post->title }}
-    </h1>
-    <h3 class="mt-4 mb-5">
-     {!! nl2br(e($post->body)) !!} 
     </h3>
-    
-    <h4 class="mt-5">コメント</h4>
+    <h4 class="mt-4 mb-5 ml-5 text-danger">
+        {!! nl2br(e($post->body)) !!} 
+    </h4>
+    <h5 class="mt-5">コメント</h5>
         <form method="post" action="{{ action('CommentsController@store', $post) }}" >
             @csrf
             <div class="form-group mt-3">
@@ -23,7 +28,7 @@
             </div>
             <input type="submit" value="コメントする" class="btn btn-primary">
         </form>
-        <table class="table table-striped table-hover mt-5">
+        <table class="table table-striped table-hover mt-4">
             <tr>
                 <th>
                     コメント
@@ -42,6 +47,9 @@
                         {{ $comment->body }}
                     </td>
                     <td class="text-secondary text-center font-weight-bold pl-5">
+                        @if (!$comment->user->image == null)
+                                <img src="{{ asset('/storage/' . $comment->user->image) }}" width="50" height="50">
+                        @endif
                         {{ optional($comment->user)->name }}
                     </td>
                     @auth

--- a/resources/views/uploader/index.blade.php
+++ b/resources/views/uploader/index.blade.php
@@ -4,10 +4,10 @@
 
 @section('content')
 
-    <h1 class="mb-5">
+    <h2 class="mb-5">
      プロフィール画像アップロード
-    </h1>
-    <form method="post" action="{{ route('profile_image') }}" enctype="multipart/form-data" class="form-inline">
+    </h2>
+    <form method="post" action="{{ route('profile_image') }}" enctype="multipart/form-data" class="form-inline ml-2">
         @csrf
         <div class="form-group">
           <input type="file" name="image" class="form-control">
@@ -19,7 +19,7 @@
               <span class="text-danger">{{ $message }}</span>
           @enderror
     </form>
-      <table class="table table-striped table-hover mt-5">
+      <table class="table table-striped table-hover mt-4">
           <tr>
             <th class="text-center">
               <h2>{{ $user->name }}</h2>


### PR DESCRIPTION
記事詳細画面にユーザー名とプロフィール画像を表示し、他の画面の見た目も整えたため。