### PR TITLE
Herokuで全てのページが表示出来るよう設定 #35

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: vendor/bin/heroku-php-apache2 public
+web: vendor/bin/heroku-php-apache2 public/

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -12,7 +12,7 @@ class TrustProxies extends Middleware
      *
      * @var array|string
      */
-    protected $proxies;
+    protected $proxies = '*';
 
     /**
      * The headers that should be used to detect proxies.

--- a/database/seeds/AdminsTableSeeder.php
+++ b/database/seeds/AdminsTableSeeder.php
@@ -12,6 +12,7 @@ class AdminsTableSeeder extends Seeder
     public function run()
     {
         DB::table('admins')->insert([
+            'id'                => 1,
             'name'              => 'admin',
             'email'             => 'admin@example.com',
             'password'          => Hash::make('12345678'),

--- a/database/seeds/CommentsTableSeeder.php
+++ b/database/seeds/CommentsTableSeeder.php
@@ -13,6 +13,7 @@ class CommentsTableSeeder extends Seeder
     {
         DB::table('comments')->insert([
             [
+                'id'               => 1,
                 'body'             => 'ゴッドファーザーは名作',
                 'post_id'          => 1,
                 'user_id'          => 5,
@@ -20,6 +21,7 @@ class CommentsTableSeeder extends Seeder
                 'updated_at'       => date('Y-m-d H:i:0'),
             ],
             [
+                'id'               => 2,
                 'body'             => '絞るの難しい。。',
                 'post_id'          => 1,
                 'user_id'          => 2,
@@ -27,6 +29,7 @@ class CommentsTableSeeder extends Seeder
                 'updated_at'       => date('Y-m-d H:i:1'),
             ],
             [
+                'id'               => 3,
                 'body'             => "Don’t Let Me Downもおすすめです！",
                 'post_id'          => 2,
                 'user_id'          => 2,
@@ -34,6 +37,7 @@ class CommentsTableSeeder extends Seeder
                 'updated_at'       => date('Y-m-d H:i:2'),
             ],
             [
+                'id'               => 4,
                 'body'             => '今度聴いてみます！',
                 'post_id'          => 2,
                 'user_id'          => 3,
@@ -41,6 +45,7 @@ class CommentsTableSeeder extends Seeder
                 'updated_at'       => date('Y-m-d H:i:3'),
             ],
             [
+                'id'               => 5,
                 'body'             => 'ジョージさん、イタリアのどこに行きたいですか？',
                 'post_id'          => 3,
                 'user_id'          => 3,
@@ -48,6 +53,7 @@ class CommentsTableSeeder extends Seeder
                 'updated_at'       => date('Y-m-d H:i:4'),
             ],
             [
+                'id'               => 6,
                 'body'             => 'ヴェネツィアですかね～',
                 'post_id'          => 3,
                 'user_id'          => 4,
@@ -55,6 +61,7 @@ class CommentsTableSeeder extends Seeder
                 'updated_at'       => date('Y-m-d H:i:5'),
             ],
             [
+                'id'               => 7,
                 'body'             => '寿司！！！！！',
                 'post_id'          => 4,
                 'user_id'          => 4,
@@ -62,6 +69,7 @@ class CommentsTableSeeder extends Seeder
                 'updated_at'       => date('Y-m-d H:i:6'),
             ],
             [
+                'id'               => 8,
                 'body'             => '寿司！！！！！',
                 'post_id'          => 4,
                 'user_id'          => 5,
@@ -69,6 +77,7 @@ class CommentsTableSeeder extends Seeder
                 'updated_at'       => date('Y-m-d H:i:7'),
             ],
             [
+                'id'               => 9,
                 'body'             => '黒は鉄板',
                 'post_id'          => 5,
                 'user_id'          => 2,
@@ -76,6 +85,7 @@ class CommentsTableSeeder extends Seeder
                 'updated_at'       => date('Y-m-d H:i:8'),
             ],
             [
+                'id'               => 10,
                 'body'             => '赤も好き',
                 'post_id'          => 5,
                 'user_id'          => 4,
@@ -83,6 +93,7 @@ class CommentsTableSeeder extends Seeder
                 'updated_at'       => date('Y-m-d H:i:9'),
             ],
             [
+                'id'               => 11,
                 'body'             => '消去法で選びました',
                 'post_id'          => 6,
                 'user_id'          => 2,
@@ -90,6 +101,7 @@ class CommentsTableSeeder extends Seeder
                 'updated_at'       => date('Y-m-d H:i:10'),
             ],
             [
+                'id'               => 12,
                 'body'             => '夏が一番',
                 'post_id'          => 6,
                 'user_id'          => 5,

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -13,6 +13,7 @@ class PostsTableSeeder extends Seeder
     {
         DB::table('posts')->insert([
             [
+                'id'               => 1,
                 'title'            => '好きな映画TOP3',
                 'body'             => '①ゴッドファーザー
 ②コーヒーをめぐる冒険
@@ -22,6 +23,7 @@ class PostsTableSeeder extends Seeder
                 'updated_at'       => date('Y-m-d H:i:0'),
             ],
             [
+                'id'               => 2,
                 'title'            => '好きなビートルズの曲TOP3',
                 'body'             => "1.Something
 2.I'm Only Sleeping
@@ -31,6 +33,7 @@ class PostsTableSeeder extends Seeder
                 'updated_at'       => date('Y-m-d H:i:1'),
             ],
             [
+                'id'               => 3,
                 'title'            => '行ってみたい国',
                 'body'             => 'I.イタリア
 II.フランス 
@@ -40,6 +43,7 @@ III.イギリス',
                 'updated_at'       => date('Y-m-d H:i:2'),
             ],
             [
+                'id'               => 4,
                 'title'            => '好きな寿司ネタ',
                 'body'             => '壱 鯛
 弐 ヒラマサ 
@@ -49,6 +53,7 @@ III.イギリス',
                 'updated_at'       => date('Y-m-d H:i:3'),
             ],
             [
+                'id'               => 5,
                 'title'            => '好きな色',
                 'body'             => '1.紺
 2.黒 
@@ -58,6 +63,7 @@ III.イギリス',
                 'updated_at'       => date('Y-m-d H:i:4'),
             ],
             [
+                'id'               => 6,
                 'title'            => '好きな季節',
                 'body'             => '・秋
 ・春

--- a/database/seeds/SymbolsTableSeeder.php
+++ b/database/seeds/SymbolsTableSeeder.php
@@ -13,30 +13,35 @@ class SymbolsTableSeeder extends Seeder
     {
         DB::table('symbols')->insert([
             [
+                'id'        => 1,
                 'symbol'    => '① ② ③',
                 'body'      => '①
 ②
 ③',
             ],
             [
+                'id'        => 2,
                 'symbol'    => '1. 2. 3.',
                 'body'      => '1.
 2.
 3.',         
             ],
             [
+                'id'        => 3,
                 'symbol'    => 'I. II. III.',
                 'body'      => 'I.
 II.
 III.',
             ],
             [
+                'id'        => 4,
                 'symbol'    => '壱 弐 参',
                 'body'      => '壱 
 弐 
 参 ',
             ],
             [
+                'id'         => 5,
                 'symbol'     => '・ ・ ・',
                 'body'       => '・
 ・

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -13,6 +13,7 @@ class UsersTableSeeder extends Seeder
     {
         DB::table('users')->insert([
             [
+                'id'                => 1,
                 'name'              => 'user',
                 'email'             => 'user@example.com',
                 'password'          => Hash::make('12345678'),
@@ -20,6 +21,7 @@ class UsersTableSeeder extends Seeder
                 'image'             => null,
             ],
             [
+              'id'                => 2,
               'name'              => 'ジョン',
               'email'             => 'john@example.com',
               'password'          => Hash::make('19401009'),
@@ -27,6 +29,7 @@ class UsersTableSeeder extends Seeder
               'image'             => 'black-and-white-1284026_1280_604c7e6d9ee6e.jpg',
           ],
           [
+              'id'                => 3,
               'name'              => 'ポール',
               'email'             => 'paul@example.com',
               'password'          => Hash::make('19420618'),
@@ -34,6 +37,7 @@ class UsersTableSeeder extends Seeder
               'image'             => 'bass-guitar-433969_1280_604c80d48485d.jpg',
           ],
           [
+              'id'                => 4,
               'name'              => 'ジョージ',
               'email'             => 'george@example.com',
               'password'          => Hash::make('19430225'),
@@ -41,6 +45,7 @@ class UsersTableSeeder extends Seeder
               'image'             => 'electric-guitars-311034_1280_604c82847c79d.png',
           ],
           [
+              'id'                => 5,
               'name'              => 'リンゴ',
               'email'             => 'ringo@example.com',
               'password'          => Hash::make('19400707'),

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -14,7 +14,7 @@
     RewriteCond %{REQUEST_URI} (.+)/$
     RewriteRule ^ /%1 [L,R=301]
 
-    RewriteBase /my_top3
+    RewriteBase /
 
     # Handle Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d


### PR DESCRIPTION
信用するプロキシの設定を加えることでHTTPS接続に変更し、.htaccessのRewiteBaseを/に変更することで、Herokuでドキュメントルート以外も表示可能になった。
また、各シーダーファイルにidを明記することによりHerokuで外部キー関連のエラーを出すことなくシーディングが可能になったため。