### PR TITLE
記事詳細画面のコメント欄の見た目を整える #43

### DIFF
--- a/resources/views/layouts/modal_delete_comment.blade.php
+++ b/resources/views/layouts/modal_delete_comment.blade.php
@@ -1,5 +1,5 @@
 <!-- Button trigger modal -->
-<button type="button" class="btn btn-outline-danger float-right mr-5" data-toggle="modal" data-target="#exampleModal_c{{ $comment->id }}">削除</button>
+<button type="button" class="btn btn-outline-danger" data-toggle="modal" data-target="#exampleModal_c{{ $comment->id }}">削除</button>
   
   <!-- Modal -->
   <div class="modal fade" id="exampleModal_c{{ $comment->id }}" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">

--- a/resources/views/layouts/return.blade.php
+++ b/resources/views/layouts/return.blade.php
@@ -1,4 +1,4 @@
-<a href="{{ url('/') }}" class="float-right btn btn-outline-secondary border-0">
+<a href="{{ url('/') }}" class="btn btn-outline-secondary border-0">
 <svg width="2em" height="2em" viewBox="0 0 16 16" class="bi bi-arrow-left-circle-fill" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
   <path fill-rule="evenodd" d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zm-4.5.5a.5.5 0 0 0 0-1H5.707l2.147-2.146a.5.5 0 1 0-.708-.708l-3 3a.5.5 0 0 0 0 .708l3 3a.5.5 0 0 0 .708-.708L5.707 8.5H11.5z"/>
 </svg>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -5,11 +5,17 @@
 @section('content')
     
     <h6 class="text-secondary">
-        @if (!$post->user->image == null)
-            <img src="data:image/png;base64,{{ $post->user->image }}" width="50" height="50">
-        @endif
-        {{ $post->user->name }}
-        @include('layouts.return')    
+        <div class="row justify-content-between">
+            <div class="col">
+                @if (!$post->user->image == null)
+                    <img src="data:image/png;base64,{{ $post->user->image }}" width="50" height="50">
+                @endif
+                {{ $post->user->name }}
+            </div>
+            <div class="col-auto">
+                @include('layouts.return')    
+            </div>
+        </div>
     </h6>
     <h3 class="mt-4 mb-4 ml-3 text-danger">
         {{ $post->title }}
@@ -17,54 +23,58 @@
     <h4 class="mt-4 mb-5 ml-5 text-danger">
         {!! nl2br(e($post->body)) !!} 
     </h4>
-    <h5 class="mt-5">コメント</h5>
-        <form method="post" action="{{ action('CommentsController@store', $post) }}" >
-            @csrf
-            <div class="form-group mt-3">
-                    <input type="text" name="body" placeholder="コメントを入力" value="{{ old('body') }}" class="form-control border-info">
-                    @error('body')
-                        <span class="text-danger">{{ $message }}</span>
-                    @enderror
-            </div>
-            <input type="submit" value="コメントする" class="btn btn-primary">
-        </form>
-        <table class="table table-striped table-hover mt-4">
+    <h5 class="mt-5">
+        コメント
+    </h5>
+    <form method="post" action="{{ action('CommentsController@store', $post) }}" >
+        @csrf
+        <div class="form-group mt-3">
+                <input type="text" name="body" placeholder="コメントを入力" value="{{ old('body') }}" class="form-control border-info">
+                @error('body')
+                    <span class="text-danger">{{ $message }}</span>
+                @enderror
+        </div>
+        <input type="submit" value="コメントする" class="btn btn-primary">
+    </form>
+    <table class="table table-striped table-hover mt-4">
+        <tr>
+            <th scope="col">
+                コメント
+            </th>
+            <th scope="col">
+                ユーザー
+            </th>
+            @auth
+                <th scope="col">
+                </th>
+            @endauth
+        </tr>
+        @forelse ($post->comments as $comment)
             <tr>
-                <th>
-                    コメント
-                </th>
-                <th class="text-center pl-5">
-                    ユーザー
-                </th>
-                @auth
-                    <th>
-                    </th>
-                @endauth
-            </tr>
-            @forelse ($post->comments as $comment)
-                <tr>
-                    <td>
-                        {{ $comment->body }}
-                    </td>
-                    <td class="text-secondary text-center font-weight-bold pl-5">
-                        @if (!$comment->user->image == null)
-                            <img src="data:image/png;base64,{{ $comment->user->image }}" width="50" height="50">
-                        @endif
+                <td>
+                    {{ $comment->body }}
+                </td>
+                <td class="text-secondary font-weight-bold">
+                    @if (!$comment->user->image == null)
+                        <img src="data:image/png;base64,{{ $comment->user->image }}" width="50" height="50">
+                    @endif
+                    <p>
                         {{ optional($comment->user)->name }}
-                    </td>
-                    @auth
-                        @if ($comment->user_id === $login_user_id)
-                            <td class="text-center pr-5">
-                                @include('layouts.modal_delete_comment')
-                            </td>
-                        @else
-                            <td>
-                            </td>
-                        @endif
-                    @endauth
-            @empty
-                    <td class="mt-4">コメントがありません</td>
-                </tr>
-            @endforelse
-        </table>
+                    </p>
+                </td>
+                @auth
+                    @if ($comment->user_id === $login_user_id)
+                        <td>
+                            @include('layouts.modal_delete_comment')
+                        </td>
+                    @else
+                        <td>
+                        </td>
+                    @endif
+                @endauth
+        @empty
+                <td class="mt-4">コメントがありません</td>
+            </tr>
+        @endforelse
+    </table>
 @endsection

--- a/resources/views/uploader/index.blade.php
+++ b/resources/views/uploader/index.blade.php
@@ -5,8 +5,14 @@
 @section('content')
 
     <h2 class="mb-5">
-      @include('layouts.return')    
-      プロフィール画像アップロード
+      <div class="row justify-content-between">
+        <div class="col">
+          プロフィール画像アップロード
+        </div>
+        <div class="col-auto">
+          @include('layouts.return')    
+        </div>
+      </div>
     </h2>
     <form method="post" action="{{ route('profile_image') }}" enctype="multipart/form-data" class="form-inline ml-2">
         @csrf
@@ -20,22 +26,22 @@
               <span class="text-danger">{{ $message }}</span>
           @enderror
     </form>
-      <table class="table table-striped table-hover mt-4">
-          <tr>
-            <th class="text-center">
-              <h2>{{ $user->name }}</h2>
-            </th>
-          </tr>
-          <tr>
+    <div class="row justify-content-center mt-5">  
+      <div class="col-md-8">  
+        <div class="card">  
+          <div class="card-header font-weight-bold text-center">
+            {{ $user->name }}
+          </div>
+          <div class="card-body text-center">
             @auth  
               @if (!$user->image == null)
-                  <td class="text-center">
-                    <img src="data:image/png;base64,{{ $user->image }}" width="30%" height="auto">
-                  </td>
+                <img src="data:image/png;base64,{{ $user->image }}" width="40%" height="auto">
               @else
-                <td class="mt-4 text-center">プロフィール画像がありません</td>
+                プロフィール画像がありません
               @endif
             @endauth
-          </tr>
-      </table>
+          </div>
+        </div>
+      </div>
+    </div>
 @endsection


### PR DESCRIPTION
記事詳細画面コメント欄のthタグにscope属性を追加しカラムを均等にして、画像アップロード画面のテーブルをカードに変更。また、戻るボタンの配置をグリッドレイアウトにしたため。